### PR TITLE
Fix GitHub Actions failure on manual version update

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,8 +31,13 @@ jobs:
         # 提交更改
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
-        git commit -am "chore: bump version to $VERSION"
-        git push origin main
+
+        if [[ -n $(git status --porcelain) ]]; then
+          git commit -am "chore: bump version to $VERSION"
+          git push origin main
+        else
+          echo "No changes to commit. Version is already up to date."
+        fi
 
     - name: Set up Python
       uses: actions/setup-python@v3


### PR DESCRIPTION
Updated `.github/workflows/python-publish.yml` to check for file changes using `git status --porcelain` before attempting to commit. This resolves an issue where the workflow would fail if the version was manually updated in a previous commit.

---
*PR created automatically by Jules for task [3179494338620878681](https://jules.google.com/task/3179494338620878681) started by @caoergou*